### PR TITLE
Improve error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.2.1", features = ["derive"] }
 colored = "2.0.0"
+eyre = "0.6.8"
 reqwest ={version =  "0.11.16", features=["blocking", "json"]}
 serde = {version="1.0.159", features=["derive"]}
 serde_json = "1.0.95"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 clap = { version = "4.2.1", features = ["derive"] }
 colored = "2.0.0"
 eyre = "0.6.8"
-reqwest ={version =  "0.11.16", features=["blocking", "json"]}
-serde = {version="1.0.159", features=["derive"]}
+reqwest = { version = "0.11.16", features = ["blocking", "json"] }
+serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"

--- a/src/handlers/leetcode.rs
+++ b/src/handlers/leetcode.rs
@@ -3,6 +3,7 @@ use super::user::*;
 use super::utils::*;
 use crate::file_parser::codefile::CodeFile;
 
+use eyre::Result;
 use serde::Deserialize;
 
 mod api;
@@ -27,36 +28,34 @@ impl LeetCode {
 impl LeetCode<Unauthorized> {
     /// # Authenticate with cookie
     /// Builds a new reqwest client with the cookie
-    pub fn authenticate(&self, cookie: &str) -> Result<LeetCode<Authorized>, &str> {
+    pub fn authenticate(&self, cookie: &str) -> Result<LeetCode<Authorized>> {
         let mut headers = reqwest::header::HeaderMap::with_capacity(5);
-        let Some(csrf_token) = cookie
+        let csrf_token = cookie
             .split(';')
             .find(|s| s.contains("csrftoken"))
-        else {
-            return  Err("No csrf token found");
-        };
-        let Some(csrf_token) = csrf_token.split('=').last() else{return Err("No csrf token found"); };
-        let csrf_token = csrf_token.to_string();
+            .map(|s| s.split('=').last())
+            .flatten()
+            .ok_or_else(|| eyre::eyre!("No csrf token found"))?;
+
         headers.insert(
             reqwest::header::COOKIE,
-            reqwest::header::HeaderValue::from_str(&cookie).unwrap(),
+            reqwest::header::HeaderValue::from_str(&cookie)?,
         );
         headers.insert(
                 reqwest::header::USER_AGENT,
-                reqwest::header::HeaderValue::from_str("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36").unwrap(),
+                reqwest::header::HeaderValue::from_str("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36")?,
         );
         headers.insert(
             reqwest::header::REFERER,
-            reqwest::header::HeaderValue::from_str("https://leetcode.com/").unwrap(),
+            reqwest::header::HeaderValue::from_str("https://leetcode.com/")?,
         );
         headers.insert(
             reqwest::header::HeaderName::from_static("x-csrftoken"),
-            reqwest::header::HeaderValue::from_str(csrf_token.as_str()).unwrap(),
+            reqwest::header::HeaderValue::from_str(csrf_token)?,
         );
         let client = reqwest::blocking::Client::builder()
             .default_headers(headers.clone())
-            .build()
-            .unwrap();
+            .build()?;
         Ok(LeetCode {
             state: std::marker::PhantomData::<Authorized>,
             client,

--- a/src/handlers/leetcode/api/question.rs
+++ b/src/handlers/leetcode/api/question.rs
@@ -115,8 +115,7 @@ impl LeetCode<Authorized> {
                     0, &boiler_code_vector[0].langSlug
                 );
                 std::io::stdin().read_line(&mut input)?;
-                let input = input.trim();
-                let input = input.parse::<usize>()?;
+                let input = input.trim().parse::<usize>()?;
                 boiler_code_vector.swap_remove(input)
             }
         };

--- a/src/handlers/leetcode/api/question.rs
+++ b/src/handlers/leetcode/api/question.rs
@@ -1,18 +1,21 @@
 use crate::handlers::leetcode::*;
 
+use eyre::{bail, Context, Result};
+
 impl LeetCode<Authorized> {
-    pub fn get_daily_challenge(&self) -> Result<DailyChallenge, &str> {
+    pub fn get_daily_challenge(&self) -> Result<DailyChallenge> {
         let url = "https://leetcode.com/graphql";
         let client = &self.client;
         let query = GraphqlRequest {
             query: "\n query questionOfToday {\n  activeDailyCodingChallengeQuestion {\n date\n userStatus\n link\n question {\n   acRate\n   difficulty\n   freqBar\n   frontendQuestionId: questionFrontendId\n   isFavor\n   paidOnly: isPaidOnly\n   status\n   title\n   titleSlug\n   hasVideoSolution\n   hasSolution\n   topicTags {\n  name\n  id\n  slug\n   }\n }\n  }\n}\n ".to_string(),
             variables: "{}".to_string(),
         };
-        let Ok(data) = client.post(url).json(&query).send() else {
-            return Err("Failed to fetch daily challenge from leetcode!");
-        };
+
+        let data = client.post(url).json(&query).send()?;
+
         // println!("{:?}", data.text());
         // todo!();
+
         #[derive(Deserialize)]
         #[allow(non_snake_case)]
         struct DailyChallengeWrapper {
@@ -22,33 +25,30 @@ impl LeetCode<Authorized> {
         struct Wrapper {
             data: DailyChallengeWrapper,
         }
+
         Ok(data
-            .json::<Wrapper>()
-            .map_err(|_| "Failed to parse daily challenge!")?
+            .json::<Wrapper>()?
             .data
             .activeDailyCodingChallengeQuestion)
     }
 
-    pub fn get_metadata(&self) -> Result<UserMetadata, &str> {
+    pub fn get_metadata(&self) -> Result<UserMetadata> {
         let client = &self.client;
-        let Ok(data) = client
+        let data = client
             .get("https://leetcode.com/api/problems/all/")
-            .send() else {
-                return Err("Failed to fetch metadata from leetcode!");
-            };
+            .send()
+            .wrap_err("Failed to fetch metadata from LeetCode")?;
 
         let metadata = data
             .json::<UserMetadata>()
-            .map_err(|_| "Failed to parse metadata! Try renewing cookie");
-        if let Ok(metadata) = metadata.as_ref() {
-            if metadata.user_name == "" {
-                return Err("Cookie invalid. Renew cookies");
-            }
+            .wrap_err("Failed to parse metadata, Try renewing cookie")?;
+        if metadata.user_name.is_empty() {
+            bail!("Cookie invalid. Renew cookies");
         }
-        metadata
+        Ok(metadata)
     }
 
-    pub fn question_content(&self, title_slug: &str) -> Result<LeetcodeQuestion, &str> {
+    pub fn question_content(&self, title_slug: &str) -> Result<LeetcodeQuestion> {
         let client = &self.client;
         let url = "https://leetcode.com/graphql";
         let query = GraphqlRequest {
@@ -56,9 +56,7 @@ impl LeetCode<Authorized> {
             variables: serde_json::to_string(&Variables { titleSlug: title_slug.to_string() }).unwrap(),
         };
 
-        let Ok(data) = client.post(url).json(&query).send() else {
-            return Err("Failed to fetch question id from leetcode!");
-        };
+        let data = client.post(url).json(&query).send()?;
 
         #[derive(Deserialize)]
         struct QuestionWrapper {
@@ -72,18 +70,14 @@ impl LeetCode<Authorized> {
         let query = "\n query questionEditorData($titleSlug: String!) {\n  question(titleSlug: $titleSlug) {\n questionId\n questionFrontendId\n codeSnippets {\n   lang\n   langSlug\n   code\n }\n envInfo\n enableRunCode\n  }\n}\n ";
         let varibales = serde_json::to_string(&Variables {
             titleSlug: title_slug.to_string(),
-        })
-        .unwrap();
-        let Ok(boiler_code) = client
+        })?;
+        let boiler_code = client
             .post(url)
             .json(&GraphqlRequest {
                 query: query.to_string(),
                 variables: varibales,
             })
-            .send()
-        else {
-            return Err("Failed to fetch boiler plate code!");
-        };
+            .send()?;
 
         #[derive(Debug, Deserialize)]
         #[allow(non_snake_case)]
@@ -99,51 +93,37 @@ impl LeetCode<Authorized> {
             data: WrapperData,
         }
 
-        let boiler_code_vector = boiler_code
-            .json::<Wrapper>()
-            .map_err(|_| "Failed to parse boiler plate code!")?
-            .data
-            .question
-            .codeSnippets;
+        let boiler_code_vector = boiler_code.json::<Wrapper>()?.data.question.codeSnippets;
 
-        let boiler_code_vector = boiler_code_vector
+        let mut boiler_code_vector = boiler_code_vector
             .into_iter()
             .filter(|code| code.is_supported())
             .collect::<Vec<_>>();
 
         // ask user to specify language among these options without using external lib
-        let boiler_code = if boiler_code_vector.len() == 1 {
-            boiler_code_vector.into_iter().next().unwrap()
-        } else if !boiler_code_vector.is_empty() {
-            let mut input = String::new();
-            println!("\nPlease select a language from the following options :");
-            for (i, code) in boiler_code_vector.iter().enumerate() {
-                println!("{}: {}", i, code.langSlug);
+        let boiler_code = match boiler_code_vector.len() {
+            0 => bail!("No boiler plate code available in supported language!"),
+            1 => boiler_code_vector.swap_remove(0),
+            _ => {
+                let mut input = String::new();
+                println!("\nPlease select a language from the following options :");
+                for (i, code) in boiler_code_vector.iter().enumerate() {
+                    println!("{}: {}", i, code.langSlug);
+                }
+                println!(
+                    "\nFor example : Input \"{}\" for {}",
+                    0, &boiler_code_vector[0].langSlug
+                );
+                std::io::stdin().read_line(&mut input)?;
+                let input = input.trim();
+                let input = input.parse::<usize>()?;
+                boiler_code_vector.swap_remove(input)
             }
-            println!(
-                "\nFor example : Input \"{}\" for {}",
-                0, &boiler_code_vector[0].langSlug
-            );
-            if let Err(_) = std::io::stdin().read_line(&mut input) {
-                return Err("Failed to read input!");
-            }
-            let input = input.trim();
-            let Ok(input) = input.parse::<usize>() else {
-                return Err("Invalid input!");
-            };
-            if let Some(code) = boiler_code_vector.into_iter().nth(input) {
-                code
-            } else {
-                return Err("Invalid input!");
-            }
-        } else {
-            return Err("No boiler plate code available in supported language!");
         };
+
         let mut input = String::new();
         println!("Filename (main.{}) : ", &(boiler_code.extension()));
-        if let Err(_) = std::io::stdin().read_line(&mut input) {
-            return Err("Failed to read input!");
-        }
+        std::io::stdin().read_line(&mut input)?;
         let input = input.trim();
         let filename = if input.is_empty() {
             format!("main.{}", boiler_code.extension())
@@ -152,9 +132,7 @@ impl LeetCode<Authorized> {
         };
         boiler_code.save_code(&filename, &title_slug);
 
-        data.json::<Data>()
-            .map_err(|_| "Failed to parse question content!")
-            .map(|op| op.data.question)
+        Ok(data.json::<Data>().map(|op| op.data.question)?)
     }
 
     pub fn question_metadata(&self, title_slug: &str) -> Result<Question, &str> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,8 @@ use crate::utils::{execute_testcases, submit};
 use args::Commands;
 use clap::Parser;
 use colored::Colorize;
+use eyre::{bail, Result};
 use handlers::leetcode::LeetCode;
-
-use std::process::ExitCode;
 
 mod args;
 mod file_parser;
@@ -17,65 +16,31 @@ mod utils;
 
 const LC_COOKIE_ENV_KEY: &str = "LC_COOKIE";
 
-fn main() -> ExitCode {
+fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    let Some(cookie) = std::env::var_os(LC_COOKIE_ENV_KEY) else {
-        eprintln!("{} is not set in the environment.", LC_COOKIE_ENV_KEY);
-        return ExitCode::FAILURE;
-    };
-    let Some( cookie) = cookie.to_str() else {
-        eprintln!("Invalid characted found in cookie!");
-        return ExitCode::FAILURE;
-    };
+    let cookie = std::env::var_os(LC_COOKIE_ENV_KEY)
+        .ok_or_else(|| eyre::eyre!("{} is not set in the environment.", LC_COOKIE_ENV_KEY))?
+        .into_string()
+        .map_err(|_| eyre::eyre!("Invalid Unicode found"))?;
 
-    let lc = LeetCode::new();
-    let lc = lc.authenticate(cookie).unwrap();
+    let lc = LeetCode::new().authenticate(&cookie)?;
 
     match cli.command {
-        Some(Commands::Auth) => {
-            let metadata = lc.get_metadata();
-            if metadata.is_ok() {
-                println!("Authenticated successfully!\n");
-                metadata.unwrap().display();
-                ExitCode::SUCCESS
-            } else {
-                let error = metadata.unwrap_err();
-                eprintln!("Authentication Error : {}", error);
-                ExitCode::FAILURE
-            }
-        }
+        Some(Commands::Auth) => match lc.get_metadata() {
+            Ok(metadata) => metadata.display(),
+            Err(err) => bail!(err),
+        },
         Some(Commands::DailyChallenge) => {
-            let daily_challenge = lc.get_daily_challenge();
-            if daily_challenge.is_ok() {
-                let daily_challenge = daily_challenge.unwrap();
-                println!("Today's Daily Challenge :");
-                println!("{}", &daily_challenge);
-                let title = daily_challenge.question.titleSlug;
-                let question = lc.question_content(&title);
-                if question.is_ok() {
-                    let question = question.unwrap();
-                    // save to filename
-                    let filename = "daily_challenge.html";
-                    if let Ok(_) = std::fs::write(filename, question.content) {
-                        println!("Saved question as HTML to {}", filename.cyan());
-                        open_html(filename);
-                        ExitCode::SUCCESS
-                    } else {
-                        eprintln!("Error saving question as HTML");
-                        ExitCode::FAILURE
-                    }
-                } else {
-                    eprintln!("Error getting question content : {}", question.unwrap_err());
-                    ExitCode::FAILURE
-                }
-            } else {
-                eprintln!(
-                    "Error getting daily challenge : {}",
-                    daily_challenge.unwrap_err()
-                );
-                ExitCode::FAILURE
-            }
+            let daily_challenge = lc.get_daily_challenge()?;
+            println!("Today's Daily Challenge: {}", daily_challenge);
+            let title = daily_challenge.question.titleSlug;
+            let question = lc.question_content(&title)?;
+
+            let filename = "daily_challenge.html";
+            std::fs::write(filename, question.content)?;
+            println!("Saved question as HTML to {}", filename.cyan());
+            open_html(filename);
         }
         Some(Commands::Question { question_name }) => {
             let question_name = if let Some(idx) = question_name.find("leetcode.com/problems/") {
@@ -85,64 +50,53 @@ fn main() -> ExitCode {
             } else {
                 &question_name
             };
-            let question = lc.question_content(question_name);
-            if question.is_ok() {
-                let question = question.unwrap();
-                let filename = format!("{}.html", question_name);
-                // save to filename
-                if let Ok(_) = std::fs::write(&filename, question.content) {
-                    println!("Saved question as HTML to {}", filename.cyan());
-                    open_html(&filename);
-                    ExitCode::SUCCESS
-                } else {
-                    eprintln!("Error saving question as HTML");
-                    ExitCode::FAILURE
-                }
-            } else {
-                eprintln!("Error getting question content : {}", question.unwrap_err());
-                ExitCode::FAILURE
-            }
+            let question = lc.question_content(question_name)?;
+            let filename = format!("{}.html", question_name);
+
+            // save to filename
+            std::fs::write(&filename, question.content)?;
+            println!("Saved question as HTML to {}", filename.cyan());
+            open_html(&filename);
         }
         Some(Commands::RunCustom {
             testcases,
             filename,
         }) => {
-            if execute_testcases(filename, Some(testcases), &lc).0 {
-                ExitCode::SUCCESS
-            } else {
-                ExitCode::FAILURE
-            }
+            let success = execute_testcases(filename, Some(testcases), &lc).0;
+            if !success {
+                bail!("Failed to execute Testcases");
+            };
         }
         Some(Commands::Run { filename }) => {
-            if execute_testcases(filename, None, &lc).0 {
-                ExitCode::SUCCESS
-            } else {
-                ExitCode::FAILURE
-            }
+            let success = execute_testcases(filename, None, &lc).0;
+            if !success {
+                bail!("Failed to execute"); // TODO: Fill the err message
+            };
         }
         Some(Commands::FastSubmit { filename }) => {
-            let code_file = if filename.is_some() {
-                CodeFile::from_file(&filename.unwrap())
+            let code_file = if let Some(path) = filename {
+                CodeFile::from_file(&path)
             } else {
                 CodeFile::from_dir()
             };
 
-            submit(&lc, code_file)
+            submit(&lc, code_file); // TODO(nozwock): Use thiserror for SubmissionResult
         }
         Some(Commands::Submit { filename }) => {
             let (testcase_result, code_file) = execute_testcases(filename, None, &lc);
-            if !testcase_result {
-                println!(
+            if testcase_result {
+                submit(&lc, code_file);
+            } else {
+                bail!(
                     "{}",
                     "Aborting submission due to failed testcase(s)!"
                         .red()
                         .bold()
                 );
-                ExitCode::FAILURE
-            } else {
-                submit(&lc, code_file)
             }
         }
-        None => ExitCode::SUCCESS,
-    }
+        None => {}
+    };
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,12 +15,13 @@ mod file_parser;
 mod handlers;
 mod utils;
 
+const LC_COOKIE_ENV_KEY: &str = "LC_COOKIE";
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    let key = "LC_COOKIE";
-    let Some(cookie) = std::env::var_os(key) else {
-        eprintln!("{} is not set in the environment.", key);
+    let Some(cookie) = std::env::var_os(LC_COOKIE_ENV_KEY) else {
+        eprintln!("{} is not set in the environment.", LC_COOKIE_ENV_KEY);
         return ExitCode::FAILURE;
     };
     let Some( cookie) = cookie.to_str() else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,9 +70,9 @@ fn main() -> Result<()> {
         }
         Some(Commands::FastSubmit { filename }) => {
             let code_file = if let Some(path) = filename {
-                CodeFile::from_file(&path)
+                CodeFile::from_file(&path)?
             } else {
-                CodeFile::from_dir()
+                CodeFile::from_dir()?
             };
 
             submit(&lc, code_file)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,16 +62,11 @@ fn main() -> Result<()> {
             testcases,
             filename,
         }) => {
-            let success = execute_testcases(filename, Some(testcases), &lc).0;
-            if !success {
-                bail!("Failed to execute Testcases");
-            };
+            _ = execute_testcases(filename, Some(testcases), &lc)?;
+            // bail if `is_correct == false`?
         }
         Some(Commands::Run { filename }) => {
-            let success = execute_testcases(filename, None, &lc).0;
-            if !success {
-                bail!("Failed to execute"); // TODO: Fill the err message
-            };
+            _ = execute_testcases(filename, None, &lc)?;
         }
         Some(Commands::FastSubmit { filename }) => {
             let code_file = if let Some(path) = filename {
@@ -80,18 +75,16 @@ fn main() -> Result<()> {
                 CodeFile::from_dir()
             };
 
-            submit(&lc, code_file); // TODO(nozwock): Use thiserror for SubmissionResult
+            submit(&lc, code_file)?;
         }
         Some(Commands::Submit { filename }) => {
-            let (testcase_result, code_file) = execute_testcases(filename, None, &lc);
-            if testcase_result {
-                submit(&lc, code_file);
+            let (is_correct, code_file) = execute_testcases(filename, None, &lc)?;
+            if is_correct {
+                submit(&lc, code_file)?;
             } else {
                 bail!(
                     "{}",
-                    "Aborting submission due to failed testcase(s)!"
-                        .red()
-                        .bold()
+                    "Aborting submission due to failed testcase(s)".red().bold()
                 );
             }
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,10 @@
 use crate::file_parser::codefile::CodeFile;
 use crate::handlers::leetcode::{Authorized, LeetCode};
 use crate::handlers::utils::{ExecutionResult, SubmissionResult};
+
 use colored::Colorize;
+use eyre::Result;
+
 use std::process::ExitCode;
 
 pub(crate) fn execute_testcases(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,17 +4,16 @@ use crate::handlers::utils::{ExecutionResult, SubmissionResult};
 
 use eyre::{bail, Result};
 
-use std::process::ExitCode;
-
+/// The first element of the return tuple indicates whether the answer is correct.
 pub(crate) fn execute_testcases(
     filename: Option<String>,
     testcases: Option<String>,
     lc: &LeetCode<Authorized>,
 ) -> Result<(bool, CodeFile)> {
     let code_file = if let Some(path) = filename {
-        CodeFile::from_file(&path)
+        CodeFile::from_file(&path)?
     } else {
-        CodeFile::from_dir()
+        CodeFile::from_dir()?
     };
 
     match testcases {


### PR DESCRIPTION
In this PR, I have focused solely on making changes related to error handling.

We are utilizing `eyre` instead of `anyhow` here because `eyre` automatically provides line and column information for errors. I haven't explored whether there is an effortless way to achieve the same with `anyhow` yet.